### PR TITLE
Use absolute node path

### DIFF
--- a/mqtt-energenie-ener314rt.service
+++ b/mqtt-energenie-ener314rt.service
@@ -8,7 +8,7 @@ Environment=
 Type=simple
 User=pi
 WorkingDirectory=/home/pi/mqtt-energenie-ener314rt
-ExecStart=node app.js
+ExecStart=/usr/bin/node app.js
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Fixes issue #8  with service not starting due to lack of absolute path 