### PR TITLE
Prefix `device_name` to `entity_name`

### DIFF
--- a/app.js
+++ b/app.js
@@ -703,6 +703,11 @@ function publishDiscovery( device, index ){
 					var unique_id = `ener314rt-${object_id}`;
 					var entity_name = `${parameter.id.toLowerCase().replace(/_/g, ' ')}`
 					var device_name = `${device_defaults.mdl} ${device.deviceId}`;
+					if (CONFIG.discovery_entityname_prefix_with_devicename) {
+						// Since Home Assistant builds the `entity_id` from the `name` property of an HA discovery packet, this ensures entity_ids are more specific than just `apparent_power` or similar
+						// Home Assistant will not display the (somewhat redundant) device name when showing the entities in the UI, because it will match the device name
+						entity_name = `${device_name} ${entity_name}`;
+					};
 /*
 					if ((parameter.component == 'switch') ||
 					   (parameter.component == 'binary_sensor' && (parameter.id == 'MOTION_DETECTOR' || parameter.id == 'DOOR_SENSOR') )) {

--- a/config_sample.json
+++ b/config_sample.json
@@ -8,6 +8,7 @@
     },
     "monitoring": true,
     "discovery_prefix": "homeassistant/",
+    "discovery_entityname_prefix_with_devicename": true,
     "ook_xmits": 10,
     "fsk_xmits": 5,
     "log_level": "info"


### PR DESCRIPTION
Since Home Assistant builds the `entity_id` from the `name` property of an HA discovery packet, this ensures `entity_id`s are more specific than just `apparent_power`.

When displaying the entities, particularly on the device page, Home Assistant will omit the device name part of the string, because it will match the device name and that's how HA device-->entity hierarchy is maintained in the display names.

Having descriptive/specific `entity_id` is useful when only being able to glance at the `entity_id` in a config. Similarly, the entity name containing the device name means that if you update the device name, all the entity (display) names of that device also update to match.

Specific name and id make auto-complete/entity-only views clearer when trying to pick something like a `reactive_power` amongst a list of multiple of them; because now the entity ID or display name tell you which device without having to look it up separately.

How will this affect existing users?
- Users who do not update their `config.json`: Nothing
   The config item `discovery_entityname_prefix_with_devicename` will be null because it won't exist, so it won't update the `entity_name` and it will stay the same as it was in previous versions.
- Users who DO update their `config.json`: Existing entities in HA will have the display name updated to include the device name, but the `entity_id` will not update due to this potentially being a breaking change.

All new users, or any existing users who configure the option AND delete their existing Home Assistant objects will see the intended behaviour, with all `entity_id` having the device id specified in it.

Any existing users who want this change, but are not wishing to lose the history of objects already added can update the `entity_id` for each entity manually before or after adding `"discovery_entityname_prefix_with_devicename": true` to their config file.