### PR TITLE
Update mqtt-energenie-ener314rt.service

### DIFF
--- a/mqtt-energenie-ener314rt.service
+++ b/mqtt-energenie-ener314rt.service
@@ -10,6 +10,8 @@ User=pi
 WorkingDirectory=/home/pi/mqtt-energenie-ener314rt
 ExecStart=/usr/bin/node app.js
 Restart=on-failure
+StartLimitBurst=3
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Added:
StartLimitBurst=3
RestartSec=10

To fix systemd service start request repeated too quickly, refusing to start limit, if application runs into an issue. Avoiding systemd from stopping the application.

```
systemd[1]: mqtt-energenie-ener314rt.service: Start request repeated too quickly.
systemd[1]: mqtt-energenie-ener314rt.service: Failed with result 'exit-code'.
systemd[1]: Failed to start Energenie ener314rt MQTT client.
```