### PR TITLE
Feature/#104 ook tx profiles - have added ook_tx_profiles for different OOK devices.  Added a queue system to process sequentially.

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,6 +56,13 @@ const MIHO033 = 13;
 const MIHO069 = 18;
 const MIHO089 = 19;
 
+// MessageQueue - provide a queue so that multiple
+// messages are processed one at a time
+const messageQueue = [];
+let processingQueue = false; 	// boolean to indicate items in queue
+let requestCounter = 0;			// Used in sendAndWait
+								// requestCounter - used to apply a counterId to message queue requests 
+
 // retry state object
 const rstate = {};
 
@@ -502,7 +509,8 @@ client.on('message', function (topic, msg, packet) {
 	if (ener_cmd !== undefined) {
 		// Send request to energenie process, any responses are handled by forked.on('message')
 		log.http("command", "%j", ener_cmd);
-		forked.send(ener_cmd);
+		// forked.send(ener_cmd);
+		queueMessage(msg);
 	} else {
 		log.warn('cmd',"Invalid MQTT device/command %j:%j",cmd_array[MQTTM_DEVICE],msg);
 	}
@@ -1167,4 +1175,93 @@ function runAtSpecificTimeOfDay(hour, minutes, func)
     // run every 24 hours from now on
     setInterval(func, twentyFourHours);
   }, eta_ms);
+}
+
+
+/**
+ * Queue Message
+ * 
+ * @param {object} msg - the message to send
+ */
+function queueMessage(msg) {
+	const delay = msg.txParameters?.delay || 0;
+	messageQueue.push({msg, delay});
+	processQueue();
+}
+
+
+/**
+ * Process a queue of message, and stop flooding of ener314-rt
+ * 
+ * Waits for child to finish each message before sending the next
+ */
+function processQueue() {
+	if (processingQueue) return;
+
+	processingQueue = true;
+	const next = async () => {
+		if (messageQueue.length === 0) {
+			processingQueue = false;
+			return;
+		}
+
+		const { msg, delay } = messageQueue[0];
+
+		const ts = new Date().toISOString();
+		log.verbose('processQueue', `${ts} - Sending message:`, msg, `(delay after send: ${delay}ms)`);
+
+		try {
+			await sendAndWait(msg);
+		} catch (err) {
+			log.error('processQueue', 'Error waiting for child:', err);
+		}
+
+		messageQueue.shift();
+		
+		setTimeout(next, delay);
+	}
+
+	next();
+}
+
+
+/**
+ * SendAndWait for child process to report bac it has successfully
+ * processed the RF message.
+ * 
+ * Have applied a requestId, to be used to monitor the appropriate send
+ * message.
+ * 
+ * Safety: will automatically timeout after 10 seconds.
+ * 
+ * @param {object} msg
+ * @return Promise<any>
+ */
+function sendAndWait(msg) {
+	return new Promise((resolve, reject) => {
+
+		const requestId = ++requestCounter;
+		const payload   = {
+			...msg, requestId
+		};
+
+		const timeout = setTimeout( () => {
+			forked.removeListener('message', onMessage);
+			reject(new Error("Child response timeout"));
+		}, 10000);  // Safety timeout if nothing comes back after 10 seconds
+
+		function onMessage(response) {
+			if (!response || response.requestId !== requestId && 
+				response.done === true
+			) {
+				// A message which has been returned mactching the requestID
+				return;
+			}
+			clearTimeout(timeout);
+			forked.removeListener('message', onMessage);
+		}
+
+		forked.on('message', onMessage);
+		forked.send(payload);
+	});
 }

--- a/app.js
+++ b/app.js
@@ -1265,3 +1265,45 @@ function sendAndWait(msg) {
 		forked.send(payload);
 	});
 }
+
+
+/**
+ * @typedef {Object} TxState
+ * @property {number} outer_loop - Number of outer loop repititions
+ * @property {number} delay - delay between outer_loops in milliseconds (applies delay on last loop too)
+ * @property {number} ook_transmits - inner transmits of message
+ */
+
+/**
+ * @typedef {Object} TxStates
+ * @property {TxState} on - Parameters for the "on" state
+ * @property {TxState} off - Parameters for the "off" state
+ * @property {TxState} [brightness] - Optional parameters for "brightness"
+ */
+
+/**
+ * Retrieved tx_profiles from the config.json
+ * 
+ * @param {string} deviceType - The device type to get parameter for
+ * @param {string} state - State to retrieve (on/off/brightness)
+ * 
+ * @returns {TxStates} TX Parameters object
+ */
+function getDeviceTxParameters(deviceType, state) {
+	const mergedOptions = {};
+
+	for (const profile of Object.values(CONFIG.tx_profiles)) {
+		if (profile.devices.includes(deviceType)) {
+			if (profile[state]) {
+				// Merge this profile's stat into the mergedOptions
+				Object.assign(mergedOptions, perofile[state]);
+			}
+		}
+	}
+
+	if (Object.keys(mergedOptions).length === 0) {
+		throw new Error(`Unknown device type or state: ${deviceType} / ${state}`);
+	}
+
+	return mergedOptions;
+}

--- a/app.js
+++ b/app.js
@@ -63,6 +63,52 @@ let processingQueue = false; 	// boolean to indicate items in queue
 let requestCounter = 0;			// Used in sendAndWait
 								// requestCounter - used to apply a counterId to message queue requests 
 
+// Default OOK TX Profiles
+const DEFAULT_OOK_PROFILES = {
+	ook: {
+		on:  { outer_loop: 1, delay: 100, ook_xmits: 10 },
+		off: { outer_loop: 1, delay: 100, ook_xmits: 10 },
+		brightness: { outer_loop: 1, delay: 100, ook_xmits: 10 },
+	},
+	light_switch: {
+		on:  { outer_loop: 4, delay: 500, ook_xmits: 22 },
+        off: { outer_loop: 1, delay: 500, ook_xmits: 10 }
+	},
+	dimmable_light_switch: {
+		on:  { outer_loop: 4, delay: 500, ook_xmits: 20 },
+		off: { outer_loop: 1, delay: 500, ook_xmits: 10 },
+		brightness: {outer_loop: 1, delay: 500, ook_xmits: 10 }
+	},
+	two_gang_light_switch: {
+		on: { outer_loop: 2, delay: 3000, ook_xmits: 22},
+		off: { outer_loop: 1, delay: 500, ook_xmits: 10}
+	}
+};
+
+const DEVICE_PROFILE_MAP = {
+	ook: ook, 
+	OOK: ook,
+	o: ook,
+	ENER002: ook,
+	MIHI014: ook,
+
+	MIHO008: light_switch,
+	MIHO024: light_switch,
+	MIHO025: light_switch,
+	MIHO026: light_switch,
+
+	MIHO010: dimmable_light_switch,
+	MIHO075: dimmable_light_switch,
+	MIHO076: dimmable_light_switch,
+	MIHO077: dimmable_light_switch,
+
+	MIHO009: two_gang_light_switch,
+	MIHO071: two_gang_light_switch,
+	MIHO072: two_gang_light_switch,
+	MIHO073: two_gang_light_switch
+};
+
+
 // retry state object
 const rstate = {};
 
@@ -1319,7 +1365,7 @@ function sendAndWait(msg) {
  * 
  * @returns {TxStates} TX Parameters object
  */
-function getDeviceTxParameters(deviceType, state) {
+function getDeviceTxParametersOld(deviceType, state) {
 	const mergedOptions = {};
 
 	for (const profile of Object.values(CONFIG.ook_tx_profiles)) {
@@ -1336,4 +1382,91 @@ function getDeviceTxParameters(deviceType, state) {
 	}
 
 	return mergedOptions;
+}
+
+
+/**
+ * Resolve the effective OOK transmission parameters
+ * for a specific device and state.
+ *
+ * Resolution order (lowest → highest priority):
+ *
+ * 1. deviceType default profile definition
+ * 2. JSON profile-level override
+ * 3. JSON device-level override
+ *
+ * Device-level overrides always win.
+ *
+ * @param {string} deviceType - e.g. "MIHO008"
+ * @param {string} state - e.g. "on", "off", "brightness"
+ * @returns {{outer_loop:number, delay:number, ook_xmits:number}}
+ * @throws {Error} if device, profile, or state is invalid
+ */
+function getDevicesTxParameters(deviceType, state) {
+	// Short alias to overrides section (may be undefined)
+	const overrides = CONFIG.ook_tx_profiles ?? {};
+
+	// Resolves base profile from hard-coded device map
+	let profileType = DEVICE_PROFILE_MAP[deviceType];
+	if (!profileType) {
+		throw new Error(`Unknown device: ${deviceType}`);
+	}
+
+	// Allow JSON to override the device's profile type
+	// optional, controlled escape
+	const deviceConfig = overrides.devices?.[deviceType];
+	if (deviceConfig?.profile) {
+		profileType = deviceConfig.profile;
+
+		// Safety check to prevent invalid profile assignment
+		if (!DEFAULT_OOK_PROFILES[profileType]) {
+			throw new Error(
+        		`Invalid profile override "${profileType}" for ${deviceType}`
+      		);
+		}
+	}
+
+	// Retrieve base profile form deviceType defaults
+
+	const baseProfile = DEFAULT_OOK_PROFILES[profileType];
+	if (!baseProfile?.[state]) {
+		throw new Error(`Invalid state "${state}" for profile ${profileType}`);
+	}
+
+	// Clone base profile state as to never mutate defaults
+	let result = { ...baseProfile[state] };
+
+	/**
+	 * Apply profile-level JSON override (if present)
+  	 * Example:
+     * {
+     *   profiles: {
+     *     light_switch: {
+     *       on: { delay: 700 }
+     *     }
+     *   }
+     * }
+	 */
+	const profileOverride = overrides.profiles?.[profileType]?.[state];
+	if (profileOverride) {
+		Object.assign(result, profileOverride);
+	}
+
+	/**
+	 * Apply device-level JSON override (highest priority)
+	 * Example:
+	 * {
+	 * 	devices: {
+	 *		MIHO008: {
+	 * 			on: { outer_loop: 6 }	 	
+	 * 		}
+	 * 	}
+	 * }
+	 */
+	if (deviceConfig?.[state]) {
+		Object.assign(result, deviceConfig[state]);
+	}
+
+	// Final resolved transmission profiles
+	return result;
 }

--- a/app.js
+++ b/app.js
@@ -58,10 +58,10 @@ const MIHO089 = 19;
 
 // MessageQueue - provide a queue so that multiple
 // messages are processed one at a time
-const messageQueue = [];
-let processingQueue = false; 	// boolean to indicate items in queue
-let requestCounter = 0;			// Used in sendAndWait
-								// requestCounter - used to apply a counterId to message queue requests 
+let messageQueue = [];
+let processingQueue = false;    // boolean to indicate items in queue
+let requestCounter = 0;         // Used in sendAndWait
+                                // requestCounter - used to apply a counterId to message queue requests 
 
 // Default OOK TX Profiles
 const DEFAULT_OOK_PROFILES = {
@@ -86,26 +86,26 @@ const DEFAULT_OOK_PROFILES = {
 };
 
 const DEVICE_PROFILE_MAP = {
-	ook: ook, 
-	OOK: ook,
-	o: ook,
-	ENER002: ook,
-	MIHI014: ook,
+	ook: 'ook',
+	OOK: 'ook',
+	o: 'ook',
+	ENER002: 'ook',
+	MIHI014: 'ook',
 
-	MIHO008: light_switch,
-	MIHO024: light_switch,
-	MIHO025: light_switch,
-	MIHO026: light_switch,
+	MIHO008: 'light_switch',
+	MIHO024: 'light_switch',
+	MIHO025: 'light_switch',
+	MIHO026: 'light_switch',
 
-	MIHO010: dimmable_light_switch,
-	MIHO075: dimmable_light_switch,
-	MIHO076: dimmable_light_switch,
-	MIHO077: dimmable_light_switch,
+	MIHO010: 'dimmable_light_switch',
+	MIHO075: 'dimmable_light_switch',
+	MIHO076: 'dimmable_light_switch',
+	MIHO077: 'dimmable_light_switch',
 
-	MIHO009: two_gang_light_switch,
-	MIHO071: two_gang_light_switch,
-	MIHO072: two_gang_light_switch,
-	MIHO073: two_gang_light_switch
+	MIHO009: 'two_gang_light_switch',
+	MIHO071: 'two_gang_light_switch',
+	MIHO072: 'two_gang_light_switch',
+	MIHO073: 'two_gang_light_switch'
 };
 
 
@@ -1266,20 +1266,28 @@ function queueMessage(msg) {
 	// If OOK, remove previous queued messages
 	// with the same zone + switchNum
 	if (msg.mode === 'ook') {
-		messageQueue = messageQueue.filter(entry => {
-			const queueMessage = entry.msg;
+		// Remove duplications from queue starting at index 1
+		messageQueue = [
+			...(messageQueue[0] ? [messageQueue[0]] : []),
+			...messageQueue.slice(1).filter(entry => {
+				const queueMessage = entry.msg;
 
-			// Keep entry if 
-			// - Not OOK
-			// - OR different zone
-			// - OR different switch number
-			return !(
-				queueMessage.mode === 'ook' && 
-				queueMessage.zone === msg.zone &&
-				queueMessage.switchNum === msg.switchNum
-			);
-		});
-		
+				// Keep entry if
+				// - Not OOK
+				// - OR different zone
+				// - OR different switch number
+				const isDuplicated = (
+					queueMessage.mode === 'ook' &&
+					queueMessage.zone === msg.zone &&
+					queueMessage.switchNum === msg.switchNum
+				);
+
+				if(isDuplicated) {
+					log.verbose('queueMessage', 'Removing queue duplicate:', queueMessage);
+				}
+				return !isDuplicated;
+			})
+		];
 	}
 
 	// Push new message
@@ -1368,48 +1376,6 @@ function sendAndWait(msg) {
 
 
 /**
- * @typedef {Object} TxState
- * @property {number} outer_loop - Number of outer loop repititions
- * @property {number} delay - delay between outer_loops in milliseconds (applies delay on last loop too)
- * @property {number} ook_xmits - inner transmits of message
- */
-
-/**
- * @typedef {Object} TxStates
- * @property {TxState} on - Parameters for the "on" state
- * @property {TxState} off - Parameters for the "off" state
- * @property {TxState} [brightness] - Optional parameters for "brightness"
- */
-
-/**
- * Retrieved tx_profiles from the config.json
- * 
- * @param {string} deviceType - The device type to get parameter for
- * @param {string} state - State to retrieve (on/off/brightness)
- * 
- * @returns {TxStates} TX Parameters object
- */
-function getDeviceTxParametersOld(deviceType, state) {
-	const mergedOptions = {};
-
-	for (const profile of Object.values(CONFIG.ook_tx_profiles)) {
-		if (profile.devices.includes(deviceType)) {
-			if (profile[state]) {
-				// Merge this profile's stat into the mergedOptions
-				Object.assign(mergedOptions, profile[state]);
-			}
-		}
-	}
-
-	if (Object.keys(mergedOptions).length === 0) {
-		throw new Error(`Unknown device type or state: ${deviceType} / ${state}`);
-	}
-
-	return mergedOptions;
-}
-
-
-/**
  * Resolve the effective OOK transmission parameters
  * for a specific device and state.
  *
@@ -1426,7 +1392,7 @@ function getDeviceTxParametersOld(deviceType, state) {
  * @returns {{outer_loop:number, delay:number, ook_xmits:number}}
  * @throws {Error} if device, profile, or state is invalid
  */
-function getDevicesTxParameters(deviceType, state) {
+function getDeviceTxParameters(deviceType, state) {
 	// Short alias to overrides section (may be undefined)
 	const overrides = CONFIG.ook_tx_profiles ?? {};
 

--- a/app.js
+++ b/app.js
@@ -171,6 +171,8 @@ client.on('message', function (topic, msg, packet) {
 	// format command for passing to energenie process
 	// format is OOK: 'energenie/c/ook/zone/switchNum/command' or OT: 'energenie/c/2/deviceNum/command'
 	log.verbose('>',"%s: %s", topic, msg);
+	let ener_cmd = null;
+
 	const cmd_array = topic.split("/");
 
 	let otCommand = 0;
@@ -179,8 +181,15 @@ client.on('message', function (topic, msg, packet) {
 		case 'ook':
 		case 'OOK':
 		case 'o':
+		case 'ENER002':
+		case 'MIHO008':
+		case 'MIHO010':
+		case 'MIHO024':
+		case 'MIHO025':
+		case 'MIHO026':
 			// All ook 1-way devices
-			
+			const deviceType = cmd_array[MQTTM_DEVICE];
+
 			// Is this request for a dimmer switch?
 			if (cmd_array[MQTTM_OOK_SWITCH] == "dimmer"){
                 /*
@@ -197,18 +206,22 @@ client.on('message', function (topic, msg, packet) {
                 */
 
 				// default dimmer OFF
-				var switchNum = 1;
-				var switchState = false;
+				let switchNum = 1;
+				let switchState = false;
 
-				var brightness = String(msg);
-
+				const brightness = String(msg);
+				let txParameters = getDeviceTxParameters(deviceType, 'brightness');
 				// Brightness steps vary
 				switch (brightness) {
+					case 'off':
 					case 'OFF':
 					case '0':
 						// off
+						txParameters = getDeviceTxParameters(deviceType, 'off');
 						break;
+					case 'on':
 					case 'ON':		// unused by Home Assistant as it should send brightness
+						txParameters = getDeviceTxParameters(deviceType, 'on');
 						switchState = true;
 						break;
 					case '1':
@@ -243,16 +256,19 @@ client.on('message', function (topic, msg, packet) {
 						log.warn('>', "Invalid brightness %s for %j", brightness, cmd_array[MQTTM_OOK_ZONE]);
 						return;
                 } // switch
-				var ener_cmd = { cmd: 'send', mode: 'ook', repeat: ook_xmits, brightness: brightness, zone: cmd_array[MQTTM_OOK_ZONE], switchNum: switchNum, switchState: switchState };
+				ener_cmd = { cmd: 'send', mode: 'ook', repeat: txParameters.ook_transmit, brightness: brightness, zone: cmd_array[MQTTM_OOK_ZONE], switchNum: switchNum, switchState: switchState, productId: deviceType, txParameters: txParameters };
 
 			} else {
 				//validate standard on/off request, default to OFF
-				var switchState = false;
+				let switchState = false;
 				if (typeof msg == typeof true)
 					switchState = msg;
 				else if (msg == "ON" || msg == "on" || msg == 1 || msg == '1')
 					switchState = true;
-				var ener_cmd = { cmd: 'send', mode: 'ook', repeat: ook_xmits, zone: cmd_array[MQTTM_OOK_ZONE], switchNum: cmd_array[MQTTM_OOK_SWITCH], switchState: switchState };
+				
+				const txParameters = getDeviceTxParameters(deviceType, switchState ? 'on' : 'off');
+				
+				ener_cmd = { cmd: 'send', mode: 'ook', repeat: txParameters.ook_transmit, zone: cmd_array[MQTTM_OOK_ZONE], switchNum: cmd_array[MQTTM_OOK_SWITCH], switchState: switchState, productId: deviceType, txParameters: txParameters };
 			}
 			break;
 		case '2':
@@ -260,12 +276,12 @@ client.on('message', function (topic, msg, packet) {
 			// MIHO005 - Adaptor+
 
 			//validate on/off request, default to OFF
-			var switchState = false;
+			let switchState = false;
 			if (typeof msg == typeof true)
 				switchState = msg;
 			else if (msg == "ON" || msg == "on" || msg == 1 || msg == '1')
 				switchState = true;
-			var ener_cmd = {
+			ener_cmd = {
 				cmd: 'send', mode: 'fsk', repeat: fsk_xmits, command: 'switch', 
 				productId: cmd_array[MQTTM_OT_PRODUCTID],
 				deviceId: cmd_array[MQTTM_OT_DEVICEID],
@@ -410,7 +426,7 @@ client.on('message', function (topic, msg, packet) {
 
 
 				// All eTRV commands are cached
-				var ener_cmd = {
+				ener_cmd = {
 					cmd: 'cacheCmd', mode: 'fsk', repeat: fsk_xmits,
 					command: cmd_array[MQTTM_OT_CMD],
 					productId: Number(cmd_array[MQTTM_OT_PRODUCTID]),
@@ -478,7 +494,7 @@ client.on('message', function (topic, msg, packet) {
 				}
 
 				// Thermostat commands are cached
-				var ener_cmd = {
+				ener_cmd = {
 					cmd: 'cacheCmd', mode: 'fsk', repeat: fsk_xmits,
 					command: cmd_array[MQTTM_OT_CMD],
 					productId: Number(cmd_array[MQTTM_OT_PRODUCTID]),
@@ -506,11 +522,11 @@ client.on('message', function (topic, msg, packet) {
 			// Undefined device
 	} // switch MQTTM_DEVICE
 
-	if (ener_cmd !== undefined) {
+	if (ener_cmd !== null) {
 		// Send request to energenie process, any responses are handled by forked.on('message')
 		log.http("command", "%j", ener_cmd);
 		// forked.send(ener_cmd);
-		queueMessage(msg);
+		queueMessage(ener_cmd);
 	} else {
 		log.warn('cmd',"Invalid MQTT device/command %j:%j",cmd_array[MQTTM_DEVICE],msg);
 	}
@@ -537,6 +553,7 @@ forked.on("spawn", msg => {
 	// process started succesfully, request start of the monitor loop if configured in config file
 	if (CONFIG.monitoring){
 		log.info("monitor", "starting monitoring of FSK devices...");
+		// queueMessage({ cmd: "monitor", enabled: true });
 		forked.send({ cmd: "monitor", enabled: true });
 	}
 });
@@ -551,6 +568,7 @@ forked.on("message", msg => {
 		case 'send':
 			var rtn_msg = "UNKNOWN";
 			var state_topic;
+			const prefix = msg.productId ? msg.productId : 'ook';
 			switch (msg.mode) {
 				case 'ook':
 					if (msg.brightness){
@@ -558,11 +576,12 @@ forked.on("message", msg => {
 						log.verbose('app', "dimmer: %j", msg);
 
 						// use the value of dimmer instead of switchNum
-						state_topic = `${CONFIG.topic_stub}ook/${msg.zone}/dimmer/state`;
+						state_topic = `${CONFIG.topic_stub}${prefix}/${msg.zone}/dimmer/state`;
 						rtn_msg = String(msg.brightness);
 
 					} else {
-						state_topic = `${CONFIG.topic_stub}ook/${msg.zone}/${msg.switchNum}/state`;
+						
+						state_topic = `${CONFIG.topic_stub}${prefix}/${msg.zone}/${msg.switchNum}/state`;
 						
 						if (typeof(msg.state) === 'boolean'){
 							if (msg.state) {
@@ -801,7 +820,8 @@ forked.on("message", msg => {
 									switchState: rstate[dynamicName]
 								};
 								log.http("command", "RETRY %j", ener_cmd);
-								forked.send(ener_cmd);
+								queueMessage(ener_cmd);
+								// forked.send(ener_cmd);
 							}
 						}
 					}
@@ -874,7 +894,8 @@ forked.on('exit', (code, signal) => {
 function UpdateMQTTDiscovery() {
 	if (discovery){
 		log.info('auto', "calling discovery");
-		forked.send({ cmd: "discovery", scan: false });
+		// forked.send({ cmd: "discovery", scan: false });
+		queueMessage({ cmd: "discovery", scan: false });
 	}
 }
 
@@ -1196,7 +1217,10 @@ function queueMessage(msg) {
  * Waits for child to finish each message before sending the next
  */
 function processQueue() {
-	if (processingQueue) return;
+	if (processingQueue === true) {
+		log.verbose('<', 'Already processing Queue - exiting...');
+		return;
+	}
 
 	processingQueue = true;
 	const next = async () => {
@@ -1251,14 +1275,18 @@ function sendAndWait(msg) {
 		}, 10000);  // Safety timeout if nothing comes back after 10 seconds
 
 		function onMessage(response) {
-			if (!response || response.requestId !== requestId && 
-				response.done === true
-			) {
-				// A message which has been returned mactching the requestID
-				return;
-			}
+			if ( !response ) return;
+			if (  response.requestId !== requestId ) return;
+			if (  response.done !== true ) return;
+			// if (!response || response.requestId !== requestId && 
+			// 	response.done === true
+			// ) {
+			// 	// A message which has been returned mactching the requestID
+			// 	return;
+			// }
 			clearTimeout(timeout);
 			forked.removeListener('message', onMessage);
+			resolve(response);
 		}
 
 		forked.on('message', onMessage);
@@ -1296,7 +1324,7 @@ function getDeviceTxParameters(deviceType, state) {
 		if (profile.devices.includes(deviceType)) {
 			if (profile[state]) {
 				// Merge this profile's stat into the mergedOptions
-				Object.assign(mergedOptions, perofile[state]);
+				Object.assign(mergedOptions, profile[state]);
 			}
 		}
 	}

--- a/app.js
+++ b/app.js
@@ -85,10 +85,7 @@ process.on('SIGINT', handleSignal );
 //process.on('SIGKILL', handleSignal );
 
 // read xmit defaults from config file
-let ook_xmits = 20;
 let fsk_xmits = 20;
-if (CONFIG.ook_xmits)
-	ook_xmits = CONFIG.ook_xmits;
 if (CONFIG.fsk_xmits)
 	fsk_xmits = CONFIG.fsk_xmits;
 // cached retries
@@ -182,11 +179,22 @@ client.on('message', function (topic, msg, packet) {
 		case 'OOK':
 		case 'o':
 		case 'ENER002':
+		case 'MIHO014':
+		// single light switch
 		case 'MIHO008':
-		case 'MIHO010':
 		case 'MIHO024':
 		case 'MIHO025':
 		case 'MIHO026':
+		// dimmable single light switch - tested
+		case 'MIHO010':
+		case 'MIHO075':
+		case 'MIHO076':
+		case 'MIHO077':
+		// two gang light switch - unable to test	
+		case 'MIHO009':
+		case 'MIHO071':
+		case 'MIHO072':
+		case 'MIHO073':
 			// All ook 1-way devices
 			const deviceType = cmd_array[MQTTM_DEVICE];
 
@@ -256,7 +264,7 @@ client.on('message', function (topic, msg, packet) {
 						log.warn('>', "Invalid brightness %s for %j", brightness, cmd_array[MQTTM_OOK_ZONE]);
 						return;
                 } // switch
-				ener_cmd = { cmd: 'send', mode: 'ook', repeat: txParameters.ook_transmit, brightness: brightness, zone: cmd_array[MQTTM_OOK_ZONE], switchNum: switchNum, switchState: switchState, productId: deviceType, txParameters: txParameters };
+				ener_cmd = { cmd: 'send', mode: 'ook', repeat: txParameters.ook_xmits, brightness: brightness, zone: cmd_array[MQTTM_OOK_ZONE], switchNum: switchNum, switchState: switchState, productId: deviceType, txParameters: txParameters };
 
 			} else {
 				//validate standard on/off request, default to OFF
@@ -268,7 +276,7 @@ client.on('message', function (topic, msg, packet) {
 				
 				const txParameters = getDeviceTxParameters(deviceType, switchState ? 'on' : 'off');
 				
-				ener_cmd = { cmd: 'send', mode: 'ook', repeat: txParameters.ook_transmit, zone: cmd_array[MQTTM_OOK_ZONE], switchNum: cmd_array[MQTTM_OOK_SWITCH], switchState: switchState, productId: deviceType, txParameters: txParameters };
+				ener_cmd = { cmd: 'send', mode: 'ook', repeat: txParameters.ook_xmits, zone: cmd_array[MQTTM_OOK_ZONE], switchNum: cmd_array[MQTTM_OOK_SWITCH], switchState: switchState, productId: deviceType, txParameters: txParameters };
 			}
 			break;
 		case '2':
@@ -1278,12 +1286,6 @@ function sendAndWait(msg) {
 			if ( !response ) return;
 			if (  response.requestId !== requestId ) return;
 			if (  response.done !== true ) return;
-			// if (!response || response.requestId !== requestId && 
-			// 	response.done === true
-			// ) {
-			// 	// A message which has been returned mactching the requestID
-			// 	return;
-			// }
 			clearTimeout(timeout);
 			forked.removeListener('message', onMessage);
 			resolve(response);
@@ -1299,7 +1301,7 @@ function sendAndWait(msg) {
  * @typedef {Object} TxState
  * @property {number} outer_loop - Number of outer loop repititions
  * @property {number} delay - delay between outer_loops in milliseconds (applies delay on last loop too)
- * @property {number} ook_transmits - inner transmits of message
+ * @property {number} ook_xmits - inner transmits of message
  */
 
 /**
@@ -1320,7 +1322,7 @@ function sendAndWait(msg) {
 function getDeviceTxParameters(deviceType, state) {
 	const mergedOptions = {};
 
-	for (const profile of Object.values(CONFIG.tx_profiles)) {
+	for (const profile of Object.values(CONFIG.ook_tx_profiles)) {
 		if (profile.devices.includes(deviceType)) {
 			if (profile[state]) {
 				// Merge this profile's stat into the mergedOptions

--- a/app.js
+++ b/app.js
@@ -1256,11 +1256,35 @@ function runAtSpecificTimeOfDay(hour, minutes, func)
 /**
  * Queue Message
  * 
+ * If this is an OOK command, apply deduplication of 
+ * same zone + switchNum, last to the queues wins
+ * 
  * @param {object} msg - the message to send
  */
 function queueMessage(msg) {
+
+	// If OOK, remove previous queued messages
+	// with the same zone + switchNum
+	if (msg.mode === 'ook') {
+		messageQueue = messageQueue.filter(entry => {
+			const queueMessage = entry.msg;
+
+			// Keep entry if 
+			// - Not OOK
+			// - OR different zone
+			// - OR different switch number
+			return !(
+				queueMessage.mode === 'ook' && 
+				queueMessage.zone === msg.zone &&
+				queueMessage.switchNum === msg.switchNum
+			);
+		});
+		
+	}
+
+	// Push new message
 	const delay = msg.txParameters?.delay || 0;
-	messageQueue.push({msg, delay});
+	messageQueue.push({ msg, delay });
 	processQueue();
 }
 

--- a/config_sample.json
+++ b/config_sample.json
@@ -12,5 +12,18 @@
     "fsk_xmits": 5,
     "cached_retries": 10,
     "log_level": "info",
-    "retry":true
+    "retry":true,
+    "tx_profiles": {
+        "ook": {
+            "devices": ["ook", "OOK", "o", "ENER002"],
+            "on": { "outer_loop": 1, "delay": 250, "ook_transmit": 15 },
+            "off": { "outer_loop": 1, "delay": 250, "ook_transmit": 15 }
+        },
+        "light_switch": {
+            "devices": ["MIHO0008", "MIHO010"],
+            "on": { "outer_loop": 4, "delay": 500, "ook_transmit": 20 },
+            "off": { "outer_loop": 1, "delay": 500, "ook_transmit": 10 },
+            "brightness": {"outer_loop": 1, "delay": 500, "ook_transmit": 10 }
+        }
+    }
 }

--- a/config_sample.json
+++ b/config_sample.json
@@ -13,26 +13,17 @@
     "log_level": "info",
     "retry":true,
     "ook_tx_profiles": {
-        "ook": {
-            "devices": ["ook", "OOK", "o", "ENER002", "MIHO014"],
-            "on": { "outer_loop": 1, "delay": 100, "ook_xmits": 10 },
-            "off": { "outer_loop": 1, "delay": 100, "ook_xmits": 10 }
+        "profiles": {
+            "light_switch": {
+                "on": { "delay": 700 }
+            }
         },
-        "light_switch": {
-            "devices": ["MIHO008", "MIHO024", "MIHO025", "MIHO026"],
-            "on": { "outer_loop": 4, "delay": 500, "ook_xmits": 22 },
-            "off": { "outer_loop": 1, "delay": 500, "ook_xmits": 10 }
-        },
-        "dimmable_light_switch": {
-            "devices": ["MIHO010", "MIHO075", "MIHO076", "MIHO077"],
-            "on": { "outer_loop": 4, "delay": 500, "ook_xmits": 20 },
-            "off": { "outer_loop": 1, "delay": 500, "ook_xmits": 10 },
-            "brightness": {"outer_loop": 1, "delay": 500, "ook_xmits": 10 }
-        },
-        "two_gang_light_switch": {
-            "devices": ["MIHO009", "MIHO071", "MIHO072", "MIHO073"],
-            "on": { "outer_loop": 2, "delay": 3000, "ook_xmits": 22},
-            "off": { "outer_loop": 1, "delay": 500, "ook_xmits": 10}
+        "devices": {
+            "MIHO008": {
+                "profile": "dimmable_light_switch",
+                "on": { "outer_loop": 6 },
+                "brightness": { "delay": 900 }
+            }
         }
     }
 }

--- a/config_sample.json
+++ b/config_sample.json
@@ -8,22 +8,31 @@
     },
     "monitoring": true,
     "discovery_prefix": "homeassistant/",
-    "ook_xmits": 10,
     "fsk_xmits": 5,
     "cached_retries": 10,
     "log_level": "info",
     "retry":true,
-    "tx_profiles": {
+    "ook_tx_profiles": {
         "ook": {
-            "devices": ["ook", "OOK", "o", "ENER002"],
-            "on": { "outer_loop": 1, "delay": 250, "ook_transmit": 15 },
-            "off": { "outer_loop": 1, "delay": 250, "ook_transmit": 15 }
+            "devices": ["ook", "OOK", "o", "ENER002", "MIHO014"],
+            "on": { "outer_loop": 1, "delay": 100, "ook_xmits": 10 },
+            "off": { "outer_loop": 1, "delay": 100, "ook_xmits": 10 }
         },
         "light_switch": {
-            "devices": ["MIHO0008", "MIHO010"],
-            "on": { "outer_loop": 4, "delay": 500, "ook_transmit": 20 },
-            "off": { "outer_loop": 1, "delay": 500, "ook_transmit": 10 },
-            "brightness": {"outer_loop": 1, "delay": 500, "ook_transmit": 10 }
+            "devices": ["MIHO008", "MIHO024", "MIHO025", "MIHO026"],
+            "on": { "outer_loop": 4, "delay": 500, "ook_xmits": 22 },
+            "off": { "outer_loop": 1, "delay": 500, "ook_xmits": 10 }
+        },
+        "dimmable_light_switch": {
+            "devices": ["MIHO010", "MIHO075", "MIHO076", "MIHO077"],
+            "on": { "outer_loop": 4, "delay": 500, "ook_xmits": 20 },
+            "off": { "outer_loop": 1, "delay": 500, "ook_xmits": 10 },
+            "brightness": {"outer_loop": 1, "delay": 500, "ook_xmits": 10 }
+        },
+        "two_gang_light_switch": {
+            "devices": ["MIHO009", "MIHO071", "MIHO072", "MIHO073"],
+            "on": { "outer_loop": 2, "delay": 3000, "ook_xmits": 22},
+            "off": { "outer_loop": 1, "delay": 500, "ook_xmits": 10}
         }
     }
 }

--- a/energenie.js
+++ b/energenie.js
@@ -272,6 +272,7 @@ if (ret==0){
  * @param {object} msg 
  */
 async function sendOOKSwitch(zone, switchNum, switchState, xmits, msg) {
+    // ener314rt.stopMonitoring(); // TODO: should the monitoring be paused while processing OOK?
     const outerLoop = msg.txParameters?.outer_loop || 1;
     const delay = msg.txParameters?.delay || 0;
     for(let i = 0; i < outerLoop; i++) {
@@ -280,4 +281,5 @@ async function sendOOKSwitch(zone, switchNum, switchState, xmits, msg) {
         var ret = ener314rt.ookSwitch(zone, switchNum, switchState, xmits);
         await new Promise(r => setTimeout(r, delay));
     }
+    // startMonitoringThread(); // TODO: start the monitoring of the monitoring?
 }

--- a/energenie.js
+++ b/energenie.js
@@ -46,8 +46,10 @@ this.events = new events.EventEmitter();
 var ener314rt = require('energenie-ener314rt');
 
 // main processing section that does stuff when asked by parent
-process.on('message', msg => {
+process.on('message', async msg => {
     log.verbose("energenie","cmd: %j", msg);
+    const { requestId } = msg;
+
     switch (msg.cmd) {
         case 'send':
             // Check xmit times (advanced), 26ms per payload transmission
@@ -57,6 +59,7 @@ process.on('message', msg => {
             switch (msg.mode) {
                 case 'ook':
                 case 'OOK':
+
                     // Check and set parameters
                     let zone = Number(msg.zone);
                     if (zone < 0 || zone > 1048575 || isNaN(zone)) {
@@ -72,7 +75,8 @@ process.on('message', msg => {
 
                     // Invoke C function to do the send
                     if (initialised){
-                        var ret = ener314rt.ookSwitch(zone, switchNum, switchState, xmits);
+                        await sendOOKSwitch(zone, switchNum, switchState, xmits, msg);
+                        // var ret = ener314rt.ookSwitch(zone, switchNum, switchState, xmits);
                         // ignore ret as workaround for https://github.com/Achronite/energenie-ener314rt/issues/32
                         msg.state = switchState;
                     } else {
@@ -82,7 +86,9 @@ process.on('message', msg => {
                     }
 
                     // return result to parent
-                    process.send(msg);
+                    process.send({
+                        ...msg, requestId, done: true 
+                    });
 
                     break;
                 case 'fsk':
@@ -108,7 +114,10 @@ process.on('message', msg => {
                                 // for emulation mode we need to respond, otherwise monitoring loop will do it for us
                                 msg.emulated = true;
                                 msg.state = switchState;
-                                process.send(msg);                                
+                                // process.send(msg);
+                                process.send({
+                                    ...msg, requestId, done: true
+                                });                                
                             }                     
 
                             break;
@@ -172,7 +181,7 @@ process.on('message', msg => {
                     // cancel
                     msg.retries = 0;
                 }
-                process.send(msg);
+                process.send({...msg, requestId, done: true });
             }
             log.verbose("energenie","cached deviceId=%d, cmd=%j, data=%j, retries=%d, res=%d", msg.deviceId, msg.otCommand, msg.data, msg.retries, res);
             break;
@@ -182,7 +191,8 @@ process.on('message', msg => {
             var discovery = JSON.parse(response);
             msg.numDevices = discovery.numDevices;
             msg.devices = discovery.devices;
-            process.send(msg);
+            // process.send(msg);
+            process.send({ ...msg, requestId, done: true });
             break;
         default:
             log.info("energenie", "Unknown or missing command: %j", msg.cmd);
@@ -245,4 +255,29 @@ if (ret==0){
     log.info("energenie", "ENER314-RT initialised succesfully");
 } else {
     log.warn("energenie", "failed to initialise ENER314-RT, err=%j, EMULATOR mode enabled",ret);
+}
+
+
+
+/**
+ * Handle send duty cycles of differing OOK devices according txParameter profiles.
+ * 
+ * Different OOK devices, need different xmit repeat cycles to hear their
+ * respective transmission.
+ * 
+ * @param {number} zone 
+ * @param {number} switchNum 
+ * @param {boolean} switchState 
+ * @param {number} xmits 
+ * @param {object} msg 
+ */
+async function sendOOKSwitch(zone, switchNum, switchState, xmits, msg) {
+    const outerLoop = msg.txParameters?.outer_loop || 1;
+    const delay = msg.txParameters?.delay || 0;
+    for(let i = 0; i < outerLoop; i++) {
+        log.verbose(`Sending message ${i+1}/${outerLoop}`);
+        // ignore ret as workaround for https://github.com/Achronite/energenie-ener314rt/issues/32
+        var ret = ener314rt.ookSwitch(zone, switchNum, switchState, xmits);
+        await new Promise(r => setTimeout(r, delay));
+    }
 }


### PR DESCRIPTION
I have been testing these code changes for the last week and have found them to work very well, I have tested with ENER002, MIHO014, MIHO008, MIHO010 and MIHO005.  I think it may still need more work but wanted to submit this for @Achronite consideration, as it might help.

### OOK Transmit Profiles

I have added to the config.json, where it is now possible to put in different ook transmit profile depending upon the device type.  For each switch type is it possible for each state to have different ook tx profiles:

```
"ook_tx_profiles": {
    "description": {
        "devices": ["device_type_1", "device_type_2"],
        "on": { "outer_loop": 1, "delay": 100, "ook_xmits": 10 },
        "off": { "outer_loop": 1, "delay": 100, "ook_xmits": 10 } 
    },
    "light_switch": {
         "devices": ["MIHO008", "MIHO024", "MIHO025", "MIHO026"],
            "on": { "outer_loop": 4, "delay": 500, "ook_xmits": 22 },
            "off": { "outer_loop": 1, "delay": 500, "ook_xmits": 10 }
        },
    "dimmable_light_switch": {
            "devices": ["MIHO010", "MIHO075", "MIHO076", "MIHO077"],
            "on": { "outer_loop": 4, "delay": 500, "ook_xmits": 20 },
            "off": { "outer_loop": 1, "delay": 500, "ook_xmits": 10 },
            "brightness": {"outer_loop": 1, "delay": 500, "ook_xmits": 10 }
        },
}
```

With an OOK type call, you now pass the actually MIHOxxx devicetype as part of the mqtt call, so instead of:
`energenie/ook/zone/switchNum/command` you pass `energenie/MIHO008/zone/switchNum/command`.  It used the device_type to apply the correct `ook_tx_profiles`.  I suspect it maybe beneficial to put these into the app.js and then still use the config.json to override default values.

As per @Achronite conclusion and @Whaleygeek suggestion, we now have a outer_loop, and a delay, as well as the original ook_xmit.  The outer_loop is a repeat of the message, of ook_xmits, and the delay happens after the ook_xmits and before the outer_loop repeats.  If configured correctly this capture the more complex duty cycles of light_switches in a powered off state.  This perhaps allows a more granular profiling.


### Queuing Call To Thread
 
With the original I was running into problems where multiple calls to the ENER314RT were being lost when sending a series of call to switch lights an sockets off/on.  I have introduced a queue system, which will queue up request, and then wait until it receives a response before processing the next request.  Ok so this slows things down a little but it almost guarantees the each message is processed in turn.

I hope this is of some use.
